### PR TITLE
トップ画面と英会話画面のサイドメニューにスレッド一覧を表示

### DIFF
--- a/app/Http/Controllers/ThreadController.php
+++ b/app/Http/Controllers/ThreadController.php
@@ -15,7 +15,10 @@ class ThreadController extends Controller
      */
     public function index(): InertiaResponse
     {
-        return Inertia::render('Top');
+        $threads = Thread::orderBy('id', 'desc')->get(); // スレッドデータを取得
+        return Inertia::render('Top', [
+            'threads' => $threads, // フロントエンドに渡す
+        ]);
     }
 
     /**
@@ -39,7 +42,10 @@ class ThreadController extends Controller
      */
     public function show(Thread $thread)
     {
-        return Inertia::render('Thread/Show');
+        $threads = Thread::orderBy('id', 'desc')->get(); // スレッドデータを取得
+        return Inertia::render('Thread/Show', [
+            'threads' => $threads, // フロントエンドに渡す
+        ]);
     }
 
     /**

--- a/resources/js/Components/SideMenu.jsx
+++ b/resources/js/Components/SideMenu.jsx
@@ -1,7 +1,7 @@
 import { Sidebar } from "flowbite-react";
 import { HiPlus, HiChatAlt2, HiOutlineChat } from "react-icons/hi";
 
-export function SideMenu() {
+export function SideMenu({ threads }) { // threadsを受け取る
     return (
         <div className="w-64 bg-orange-600 text-white h-screen overflow-y-auto">
             <div className="flex items-center p-4 text-2xl font-bold">
@@ -15,16 +15,11 @@ export function SideMenu() {
                         <span className="ml-3">新規スレッド作成</span>
                     </a>
                 </li>
-                {[
-                    "英会話スレッド1",
-                    "英会話スレッド2",
-                    "英会話スレッド3",
-                    "英会話スレッド4",
-                ].map((thread, index) => (
+                {threads.map((thread, index) => ( // threadsをループして表示
                     <li key={index}>
                         <a href="#" className="flex items-center p-2 text-base font-normal text-white hover:bg-orange-500">
                             <HiChatAlt2 className="w-6 h-6" />
-                            <span className="ml-3">{thread}</span>
+                            <span className="ml-3">{thread.title}</span> {/* タイトルを表示 */}
                         </a>
                     </li>
                 ))}

--- a/resources/js/Pages/Thread/Show.jsx
+++ b/resources/js/Pages/Thread/Show.jsx
@@ -3,12 +3,12 @@ import { SideMenu } from '../../Components/SideMenu'
 import { LogoutButton } from '../../Components/LogoutButton'
 import { HiMicrophone, HiSpeakerphone } from 'react-icons/hi'
 
-export default function Show({}) {
+export default function Top({ threads }) { // threadsを受け取る
     return (
         <>
             <Head title="Show" />
             <div className="flex h-screen overflow-hidden">
-                <SideMenu />
+                <SideMenu threads={threads} />
                 <div className="flex-1 p-4 bg-gray-200 text-white relative">
                     <div className="flex justify-end">
                         <LogoutButton />

--- a/resources/js/Pages/Top.jsx
+++ b/resources/js/Pages/Top.jsx
@@ -2,12 +2,12 @@ import { Head } from '@inertiajs/react'
 import { SideMenu } from '../Components/SideMenu'
 import { LogoutButton } from '../Components/LogoutButton'
 
-export default function Top({}) {
+export default function Top({ threads }) { // threadsを受け取る
     return (
         <>
             <Head title="Top" />
             <div className="flex h-screen">
-                <SideMenu />
+            <SideMenu threads={threads} /> {/* threadsをSideMenuに渡す */}
                 <div className="flex-1 p-4 bg-gray-800 text-white">
                     <div className="flex justify-end">
                         <LogoutButton />


### PR DESCRIPTION
- ThreadControllerのindexメソッドとshowメソッドを修正
- SideMenu.jsxを修正
- Top.jsxを修正
- Show.jsxを修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Thread views now display up-to-date thread listings retrieved dynamically from the database.
  - The side menu has been enhanced to automatically render current thread titles, improving navigation and overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->