### PR TITLE
日本語翻訳機能の実装

### DIFF
--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -91,7 +91,24 @@ class MessageController extends Controller
 
         // GPTにAPIリクエスト
         $apiService = new ApiService();
+        try {
         $gptResponse = $apiService->callTranslateApi($message->message_en);
+
+        if (!isset($gptResponse['choices'][0]['message']['content'])) {
+            Log::error('API response does not contain content field', ['response' => $gptResponse]);
+            return response()->json(['message' => '翻訳の処理に失敗しました'], 500);
+        }
+
+        $aiMessageJa = $gptResponse['choices'][0]['message']['content'];
+        $message->update([
+            'message_ja' => $aiMessageJa
+        ]);
+
+        return response()->json(['message' => $aiMessageJa], 200);
+        } catch (\Exception $e) {
+            Log::error('API call failed', ['error' => $e->getMessage()]);
+            return response()->json(['message' => '翻訳に失敗しました'], 500);
+        }
 
         $aiMessageJa = $gptResponse['choices'][0]['message']['content'];
         $message->update([

--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -105,16 +105,10 @@ class MessageController extends Controller
         ]);
 
         return response()->json(['message' => $aiMessageJa], 200);
+
         } catch (\Exception $e) {
             Log::error('API call failed', ['error' => $e->getMessage()]);
             return response()->json(['message' => '翻訳に失敗しました'], 500);
         }
-
-        $aiMessageJa = $gptResponse['choices'][0]['message']['content'];
-        $message->update([
-            'message_ja' => $aiMessageJa
-        ]);
-
-        return response()->json(['message' => $aiMessageJa], 200);
     }
 }

--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -79,4 +79,25 @@ class MessageController extends Controller
     }
     return response()->json(['message' => '音声データが保存されませんでした'], 400);
     }
+
+    public function translate(Request $request, int $threadId, int $messageId)
+    {
+        // メッセージを取得
+        $message = Message::find($messageId);
+
+        if (!$message) {
+            return response()->json(['message' => 'メッセージが見つかりませんでした'], 404);
+        }
+
+        // GPTにAPIリクエスト
+        $apiService = new ApiService();
+        $gptResponse = $apiService->callTranslateApi($message->message_en);
+
+        $aiMessageJa = $gptResponse['choices'][0]['message']['content'];
+        $message->update([
+            'message_ja' => $aiMessageJa
+        ]);
+
+        return response()->json(['message' => $aiMessageJa], 200);
+    }
 }

--- a/app/Http/Services/ApiService.php
+++ b/app/Http/Services/ApiService.php
@@ -107,4 +107,36 @@ class ApiService
         // 修正: 返すパスを相対パスに変更
         return 'ai_audio/' . $fileName; // 保存した音声のファイルパスを相対パスで返す
     }
+
+    /**
+     * 英語の文章を日本語に翻訳するためのAPIリクエスト
+     *
+     * @param string $englishText
+     * @return array
+     */
+    public function callTranslateApi($englishText)
+    {
+        $systemMessage = [
+            'role' => 'system',
+            'content' => 'Please translate the English text provided into Japanese.',
+        ];
+
+        $userMessage = [
+            'role' => 'user',
+            'content' => $englishText,
+        ];
+
+        $messages = [$systemMessage, $userMessage];
+
+        $response = Http::withHeaders([
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Bearer ' . env('OPENAI_API_KEY'),
+        ])
+        ->post('https://api.openai.com/v1/chat/completions', [
+            'model' => 'gpt-4o-mini',
+            'messages' => $messages,
+        ]);
+
+        return $response->json();
+    }
 }

--- a/app/Http/Services/ApiService.php
+++ b/app/Http/Services/ApiService.php
@@ -44,7 +44,7 @@ class ApiService
     {
         $systemMessage = [
             'role' => 'system',
-            'content' => 'You are a helpful English teacher. Please speak English.',
+            'content' => 'You are a friendly person having a casual conversation in English with the user. Respond naturally and keep the conversation engaging. Do not provide lists, extensive advice, or instructional content unless the user specifically asks for it.',
         ];
 
         $messages = $modelMessages->map(function($message) {
@@ -136,6 +136,10 @@ class ApiService
             'model' => 'gpt-4o-mini',
             'messages' => $messages,
         ]);
+
+        if (!$response->successful()) {
+            throw new \Exception('Failed to call API: ' . $response->body());
+        }
 
         return $response->json();
     }

--- a/resources/js/Pages/Thread/Show.jsx
+++ b/resources/js/Pages/Thread/Show.jsx
@@ -5,13 +5,16 @@ import { HiMicrophone, HiSpeakerphone } from 'react-icons/hi'
 import { useState, useRef, useEffect } from 'react'
 import axios from 'axios'
 
-export default function Show({ threads, messages, threadId }) {
+export default function Show({ threads, messages: initialMessages, threadId }) {
+    const [messages, setMessages] = useState(initialMessages); // messagesの状態を定義
     const [isRecording, setIsRecording] = useState(false);
     const [isLoading, setIsLoading] = useState(false); // ローディング状態を追加
     const mediaRecorderRef = useRef(null);
     const audioChunksRef = useRef([]);
     const audioRefs = useRef({}); // 音声ファイルの参照を保持
     const [playingAudio, setPlayingAudio] = useState(null);
+    const [shouldPlayAudio, setShouldPlayAudio] = useState(true); // 音声再生フラグを追加
+
 
     const handleRecording = async () => {
         if (isRecording) {
@@ -81,6 +84,33 @@ export default function Show({ threads, messages, threadId }) {
         setPlayingAudio(audio);
     };
 
+    const handleTranslate = async (messageId) => {
+        const message = messages.find(msg => msg.id === messageId);
+
+        if (!message.message_ja) {
+            // message_jaが無い場合のみリクエストを送信
+            try {
+                const response = await axios.post(`/thread/${threadId}/message/${messageId}/translate`);
+                // message_jaに翻訳結果を保持
+                const updatedMessages = messages.map(msg =>
+                    msg.id === messageId ? { ...msg, message_ja: response.data.message, showJapanese: true } : msg // 初回クリックで日本語を表示
+                );
+                // ステートを更新
+                setMessages(updatedMessages);
+                setShouldPlayAudio(false); // 音声再生を防ぐフラグを設定
+            } catch (error) {
+                console.error('翻訳に失敗しました:', error);
+                alert('翻訳に失敗しました');
+            }
+        } else {
+            // message_jaがある場合は表示を切り替え
+            const updatedMessages = messages.map(msg =>
+                msg.id === messageId ? { ...msg, showJapanese: !msg.showJapanese } : msg
+            );
+            setMessages(updatedMessages);
+        }
+    };
+
     useEffect(() => {
         // コンポーネントのアンマウント時に音声を停止
         return () => {
@@ -96,8 +126,13 @@ export default function Show({ threads, messages, threadId }) {
         const latestMessage = messages[messages.length - 1];
         if (latestMessage && latestMessage.audio_file_path && latestMessage.sender === 2) {
             handleAudioPlayback(latestMessage.audio_file_path);
+            // スクロールを一番下に設定
+            const messageContainer = document.getElementById('message-container');
+            if (messageContainer) {
+                messageContainer.scrollTop = messageContainer.scrollHeight; // スクロール位置を一番下に設定
+            }
         }
-    }, [messages]);
+    }, [messages]); // messagesが更新されるたびに実行
 
     return (
         <>
@@ -114,7 +149,7 @@ export default function Show({ threads, messages, threadId }) {
                         <LogoutButton />
                     </div>
                     <div className="flex flex-col h-full justify-between pt-8">
-                        <div className="flex flex-col space-y-4 overflow-y-auto">
+                    <div id="message-container" className="flex flex-col space-y-4 overflow-y-auto"> {/* IDを追加 */}
                         {messages.map((message, index) => (
                                 message.sender === 1 ? (
                                     // ユーザのメッセージ
@@ -133,7 +168,7 @@ export default function Show({ threads, messages, threadId }) {
                                             AI
                                         </div>
                                         <div className="bg-gray-700 p-2 rounded-lg max-w-xs">
-                                            <p>{message.message_en}</p>
+                                            <p>{message.showJapanese ? message.message_ja : message.message_en}</p> {/* 表示切り替え */}
                                         </div>
                                         <div className="flex items-center ml-2">
                                         <button
@@ -142,8 +177,11 @@ export default function Show({ threads, messages, threadId }) {
                                         >
                                                 <HiSpeakerphone size={24} />
                                             </button>
-                                            <button className="bg-gray-600 p-1 rounded-full ml-1">
-                                                Aあ
+                                            <button
+                                                className="bg-gray-600 p-1 rounded-full ml-1"
+                                                onClick={() => handleTranslate(message.id)}
+                                            >
+                                                A訳
                                             </button>
                                         </div>
                                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,5 +15,11 @@ Route::middleware('auth')->group(function () {
     // 新規スレッド作成
     Route::get('/thread', [ThreadController::class, 'store'])->name('thread.store');
     // メッセージを保存
-    Route::post('/thread/{threadId}/message', [MessageController::class, 'store'])->name('message.store')->where('threadId', '[0-9]+');
+    Route::post('/thread/{threadId}/message', [MessageController::class, 'store'])
+        ->name('message.store')->where('threadId', '[0-9]+');
+    // メッセージを日本語に翻訳
+    Route::post('/thread/{threadId}/message/{messageId}/translate', [MessageController::class, 'translate'])
+        ->name('message.translate')
+        ->where('threadId', '[0-9]+')
+        ->where('messageId', '[0-9]+');
 });


### PR DESCRIPTION
- Show.jsxに日本語翻訳ボタンのクリックイベントを追加
- web.phpにルーティングを追加
- ApiService.phpに翻訳用のgptリクエストを追加
- MessageController.phpにtranslateメソッドを作成 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced on-demand message translation from English into Japanese in the conversation view.
  - Enabled toggling between original and translated messages with automatic scrolling and controlled audio playback.

- **Chores**
  - Integrated external translation service.
  - Added a new endpoint for processing translation requests, allowing for translation of specific messages by their IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->